### PR TITLE
read proto from the standardized 'Forwarded' header

### DIFF
--- a/index.js
+++ b/index.js
@@ -643,7 +643,16 @@ function issecure(req, trustProxy) {
     ? header.substr(0, index).toLowerCase().trim()
     : header.toLowerCase().trim()
 
-  return proto === 'https';
+  if (proto === 'https') {
+    return true;
+  }
+  
+  // read proto from the standardized replacement 'Forwarded' header
+  if (req.headers['forwarded']) {
+    return req.headers['forwarded'].indexOf('proto=https') !== -1;
+  }
+
+  return false;
 }
 
 /**


### PR DESCRIPTION
Since there is a standardized replacement for `X-Forwarded-Proto`, the new [`Forwarded` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded), we should probably support this too.

This change adds a check for the new header, after all preexisting checks for `issecure`. This allows to set secure cookies when a `Forwarded: proto=https` header is present.